### PR TITLE
Fix reload of already loaded on event trigger + optional container watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,57 @@
-#unveil.js  
-###A very lightweight plugin to lazy load images  
-  
-  
-  
-Most of us are familiar with the [Lazy Load](http://www.appelsiini.net/projects/lazyload) plugin by [Mika Tuupola](http://www.appelsiini.net/).  
-This plugin is very useful and it boosts performance delaying loading of images in long web pages because images outside of viewport (visible part of web page) won't be loaded until the user scrolls to them.  
-Lazy Load has some cool options such as custom effects, container, events or data attribute. If you're not gonna use any of them you can reduce the file size by leaving just the essential code to show the images.  
-That's what I did and this is my lightweight version of Lazy Load - less than 0.5kb.  
-  
+#unveil.js
+###A very lightweight plugin to lazy load images
+
+
+
+Most of us are familiar with the [Lazy Load](http://www.appelsiini.net/projects/lazyload) plugin by [Mika Tuupola](http://www.appelsiini.net/).
+This plugin is very useful and it boosts performance delaying loading of images in long web pages because images outside of viewport (visible part of web page) won't be loaded until the user scrolls to them.
+Lazy Load has some cool options such as custom effects, container, events or data attribute. If you're not gonna use any of them you can reduce the file size by leaving just the essential code to show the images.
+That's what I did and this is my lightweight version of Lazy Load with support for serving high-resolution images to devices with retina displays - less than 1k<.
+
 Visit unveil's [project page](http://luis-almeida.github.com/unveil/) to read the documentation and see the demo.
-  
-<br>
-  
-#### Usage  
-Include the actual image source in a "data-src" attribute.  
-Use a placeholder image in the src attribute, something to be displayed while the original image loads.  
-  
-<pre>&lt;img src="bg.png" data-src="img.jpg" /></pre>  
-  
-<pre>$("img").unveil();</pre>
-  
-<br>
-  
-###Option  
-By default, images are only loaded and "unveiled" when user scrolls to them and they became visible on the screen.  
-If you want your images to load earlier than that, lets say 200px before they get visible, you just have to:  
-  
-<pre>$("img").unveil( 200 );</pre>
-  
-<br>
-  
-###Trigger  
-You can still trigger image loading whenever you need.  
-All you have to do is select the images you want to "unveil" and trigger the event:  
-  
-<pre>$("img").trigger( "unveil" );</pre>
-  
-<br>
-  
-###Demo  
+
+
+
+#### Usage
+Use a placeholder image in the src attribute - something to be displayed while the original image loads - and include the actual image source in a "data-src" attribute.
+If you want to serve high-resolution images to devices with retina displays, you just have to include the source for those images in a "data-src-retina" attribute.
+You don't need to include a "data-src-retina" attribute in all the image tags, unveil is smart enough to fallback to "data-src" or even do nothing in case there isn't any "data-src" specified.
+```html
+<img src="bg.png" data-src="img1.jpg" />
+<img src="bg.png" data-src="img2.jpg" data-src-retina="img2-retina.jpg" />
+```
+If you care about users without javascript enabled, you can include the original image inside a ```noscript``` tag:
+```html
+<noscript>
+  <img src="bg.png" data-src="img1.jpg" />
+</noscript>
+```
+Run the script on document ready:
+```javascript
+$(document).ready(function() {
+  $("img").unveil();
+});
+```
+
+
+
+###Option
+By default, images are only loaded and "unveiled" when user scrolls to them and they became visible on the screen.
+If you want your images to load earlier than that, lets say 200px before they get visible, you just have to:
+```javascript
+$("img").unveil( 200 );
+```
+
+
+
+###Trigger
+You can still trigger image loading whenever you need.
+All you have to do is select the images you want to "unveil" and trigger the event:
+```javascript
+$("img").trigger( "unveil" );
+```
+
+
+
+###Demo
 Visit [project page](http://luis-almeida.github.com/unveil/) to see it working.

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -10,47 +10,46 @@
 
 ;(function($) {
 
-  $.fn.unveil = function(threshold) {
+    $.fn.unveil = function(threshold, container) {
+        var $w = container || $(window), // Allow trigger another container than window
+            th = threshold || 0,
+            retina = window.devicePixelRatio > 1,
+            attrib = retina? "data-src-retina" : "data-src",
+            images = this,
+            loaded,
+            inview,
+            source;
 
-    var $w = $(window),
-        th = threshold || 0,
-        retina = window.devicePixelRatio > 1,
-        attrib = retina? "data-src-retina" : "data-src",
-        images = this,
-        loaded,
-        inview,
-        source;
+        this.one("unveil", function() {
+            source = this.getAttribute(attrib);
+            source = source || this.getAttribute("data-src");
 
-    this.one("unveil", function() {
-      source = this.getAttribute(attrib);
-      source = source || this.getAttribute("data-src");
-      if (source) this.setAttribute("src", source);
-    });
+            // Don't reload if already loaded
+            if (source && source != this.getAttribute('src')) { this.setAttribute("src", source); };
+        });
 
-    function unveil() {
-      inview = images.filter(function() {
-        var $e = $(this),
-            wt = $w.scrollTop(),
-            wb = wt + $w.height(),
-            et = $e.offset().top,
-            eb = et + $e.height();
+        function unveil() {
+            inview = images.filter(function() {
+                var $e = $(this),
+                    wt = $w.scrollTop(),
+                    wb = wt + $w.height(),
+                    et = $e.offset().top,
+                    eb = et + $e.height();
 
-        return eb >= wt - th && et <= wb + th;
-      });
+                return eb >= wt - th && et <= wb + th;
+            });
 
-      loaded = inview.trigger("unveil");
-      images = images.not(loaded);
-    }
+            loaded = inview.trigger("unveil");
+            images = images.not(loaded);
+        }
 
-    $w.scroll(unveil);
-    $w.resize(unveil);
+        $w.scroll(unveil);
+        $w.resize(unveil);
 
-    unveil();
+        unveil();
 
-    return this;
+        return this;
 
-  };
+    };
 
 })(jQuery);
-
-


### PR DESCRIPTION
Trigger the unveil event caused to load the already loaded images, I added a test to prevent the manipualtion of <img> with the same src attribute as the data watched.
I added a argument "container" to allow specific div watch with a fallback on window.
If you merge this modification, please update the minified file.
Trigger the event "unveil" from outside the plugin still load all images.
