### PR TITLE
Namespace event attachment

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -42,8 +42,8 @@
       images = images.not(loaded);
     }
 
-    $w.scroll(unveil);
-    $w.resize(unveil);
+    $w.on('scroll.unveil', unveil);
+    $w.on('resize.unveil', unveil);
 
     unveil();
 


### PR DESCRIPTION
Add a namespace to the `window` event attachment to allow for efficient removal via:

``` javascript
$(window).off('.unveil');
```
