### PR TITLE
Added support for slow DOM loading browser such as mobile devices

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -44,6 +44,7 @@
 
     $w.scroll(unveil);
     $w.resize(unveil);
+	$w.load(unveil);
 
     unveil();
 


### PR DESCRIPTION
In some mobile browsers such as Chrome or Safari mobile the initial viewport images weren't loading without the user scrolling. This happened due to the fact that the images weren't even inserted into the DOM tree when unveil was initialized.
The added on-load event prevents this from happening.
