### PR TITLE
Removed unnecessary window height calculations to minimize reflows.  Added an option to throttle scroll and resize events.  Cleaned up the plugin API to use an options object rather than arguments.

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,8 @@
     <script>
     $(function() {
         $("li img").unveil({
-            threshold: 2000
+            threshold: 200,
+            throttle: 1000
         });
     });
     </script>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,9 @@
 
     <script>
     $(function() {
-        $("li img").unveil(300);
+        $("li img").unveil({
+            threshold: 2000
+        });
     });
     </script>
 
@@ -128,7 +130,7 @@
     <h2>Threshold</h2>
     <p>By default, images are only loaded and "unveiled" when the user scrolls to them and they became visible on the screen.</p>
     <p>If you want your images to load earlier than that, lets say 200px before they appear on the screen, you just have to:</p>
-    <code>$(<span class="red">"img"</span>).unveil(<span class="purple">200</span>);</code>
+    <code>$(<span class="red">"img"</span>).unveil(<br>&nbsp;&nbsp;threshold: <span class="purple">200</span><br>});</code>
 
     <h2>Callback</h2>
     <p>As a second parameter you can also specify a callback function that will fire after an image as been "unveiled".</p>
@@ -138,7 +140,7 @@
     &nbsp;&nbsp;transition: opacity .3s ease-in;<br>
     }</code>
     <br><br>
-    <code>$(<span class="red">"img"</span>).unveil(<span class="purple">200</span>, <span class="blue">function</span>() {<br>
+    <code>$(<span class="red">"img"</span>).unveil({<br>&nbsp;&nbsp;threshold: <span class="purple">200</span><br>}, <span class="blue">function</span>() {<br>
     &nbsp;&nbsp;$(this).load(<span class="blue">function</span>() {<br>
     &nbsp;&nbsp;&nbsp;&nbsp;this.style.opacity = 1;<br>
     &nbsp;&nbsp;});<br>

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -14,7 +14,8 @@
 
     var $w = $(window),
         defaults = {
-          threshold: 0
+          threshold: 0,
+          throttle: 0
         };
 
     options = $.extend(defaults, options);
@@ -23,7 +24,8 @@
         retina = window.devicePixelRatio > 1,
         attrib = retina ? "data-src-retina" : "data-src",
         images = this,
-        loaded, 
+        loaded,
+        timer,
         wh, 
         eh;
 
@@ -41,7 +43,7 @@
       unveil();
     }
 
-    function unveil() {
+    function filterImages() {
       var inview = images.filter(function() {
         var $e = $(this);
         if ($e.is(":hidden")) return;
@@ -60,6 +62,17 @@
 
       loaded = inview.trigger("unveil");
       images = images.not(loaded);
+    }
+
+    function unveil() {
+      if (options.throttle) {
+          clearTimeout(timer);
+          timer = setTimeout(function () {
+            filterImages();
+          }, options.throttle);
+      } else {
+        filterImages();
+      }
     }
 
     $w.scroll(unveil);

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,7 +23,9 @@
         retina = window.devicePixelRatio > 1,
         attrib = retina ? "data-src-retina" : "data-src",
         images = this,
-        loaded;
+        loaded, 
+        wh, 
+        eh;
 
     this.one("unveil", function() {
       var source = this.getAttribute(attrib);
@@ -34,13 +36,22 @@
       }
     });
 
+    function onResize() {
+      wh = $w.height();
+      unveil();
+    }
+
     function unveil() {
       var inview = images.filter(function() {
         var $e = $(this);
         if ($e.is(":hidden")) return;
 
+        if (!wh) {
+          wh = $w.height();
+        }
+
         var wt = $w.scrollTop(),
-            wb = wt + $w.height(),
+            wb = wt + wh,
             et = $e.offset().top,
             eb = et + $e.height();
 

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -10,12 +10,18 @@
 
 ;(function($) {
 
-  $.fn.unveil = function(threshold, callback) {
+  $.fn.unveil = function(options, callback) {
 
     var $w = $(window),
-        th = threshold || 0,
+        defaults = {
+          threshold: 0
+        };
+
+    options = $.extend(defaults, options);
+
+    var $w = $(window),
         retina = window.devicePixelRatio > 1,
-        attrib = retina? "data-src-retina" : "data-src",
+        attrib = retina ? "data-src-retina" : "data-src",
         images = this,
         loaded;
 
@@ -38,7 +44,7 @@
             et = $e.offset().top,
             eb = et + $e.height();
 
-        return eb >= wt - th && et <= wb + th;
+        return eb >= wt - options.threshold && et <= wb + options.threshold;
       });
 
       loaded = inview.trigger("unveil");


### PR DESCRIPTION
- Removed unnecessary window height calculations to minimize reflows.
- Added an option to throttle scroll and resize events.
- Cleaned up the plugin API to use an options object rather than arguments.
