### PR TITLE
Support lazy load of background images

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,7 +23,11 @@
       var source = this.getAttribute(attrib);
       source = source || this.getAttribute("data-src");
       if (source) {
-        this.setAttribute("src", source);
+        if (this.tagName === "img") {
+          this.setAttribute("src", source);
+        } else {
+          this.style["background-image"] = "url('" + source + "')";
+        }
         if (typeof callback === "function") callback.call(this);
       }
     });

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,10 +23,10 @@
       var source = this.getAttribute(attrib);
       source = source || this.getAttribute("data-src");
       if (source) {
-        if (this.tagName === "img") {
+        if (this.tagName === "IMG") {
           this.setAttribute("src", source);
         } else {
-          this.style["background-image"] = "url('" + source + "')";
+          this.style["backgroundImage"] = "url('" + source + "')";
         }
         if (typeof callback === "function") callback.call(this);
       }


### PR DESCRIPTION
Support unveil on images that need to be loaded using the background-image attribute. The syntax would be the same as what is currently used for img tags. 

Usage:

```
<div data-src="img2.jpg" data-src-retina="img2-retina.jpg" style="background-image: url('bg.png')"> 
```
