### PR TITLE
makes unveil method triggerable

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -47,6 +47,7 @@
 
     $w.scroll(unveil);
     $w.resize(unveil);
+    $w.on('unveilcheck', unveil);
 
     unveil();
 


### PR DESCRIPTION
adds triggering of unveil calculations by $(window).trigger('unveilcheck');

allows to manually trigger calculations e.g. if dynamic content changes
