### PR TITLE
added some basic support for background images.

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -16,14 +16,20 @@
         th = threshold || 0,
         retina = window.devicePixelRatio > 1,
         attrib = retina? "data-src-retina" : "data-src",
+        bkg    = retina? "data-bkg-retina" : "data-bkg",
         images = this,
         loaded;
 
     this.one("unveil", function() {
-      var source = this.getAttribute(attrib);
-      source = source || this.getAttribute("data-src");
+      var bkg_source = this.getAttribute(bkg);
+      var source     = bkg_source !== undefined ? bkg_source : this.getAttribute(attrib);
+      source         = source || this.getAttribute("data-src");
       if (source) {
-        this.setAttribute("src", source);
+        if (bkg_source !== undefined) {
+          this.style.backgroundImage = "url('" + source + "')";
+        } else {
+          this.setAttribute("src", source);
+        }
         if (typeof callback === "function") callback.call(this);
       }
     });


### PR DESCRIPTION
I've added some basic background image support by adding a new data attribute of data-bkg or data-bkg-retina. It checks to see if data-bkg is defined and applies it. Might need a tiny bit more testing. But the changes are so small it should be ok.
