### PR TITLE
Allow Loading on any attribute

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -10,20 +10,22 @@
 
 ;(function($) {
 
-  $.fn.unveil = function(threshold, callback) {
+  $.fn.unveil = function(threshold, attribute, callback) {
+
+    if (!attribute) attribute = 'src';
 
     var $w = $(window),
         th = threshold || 0,
         retina = window.devicePixelRatio > 1,
-        attrib = retina? "data-src-retina" : "data-src",
+        attrib = retina? "data-" + attribute + "-retina" : "data-" + attribute,
         images = this,
         loaded;
 
     this.one("unveil", function() {
       var source = this.getAttribute(attrib);
-      source = source || this.getAttribute("data-src");
+      source = source || this.getAttribute("data-" + attribute);
       if (source) {
-        this.setAttribute("src", source);
+        this.setAttribute(attribute, source);
         if (typeof callback === "function") callback.call(this);
       }
     });


### PR DESCRIPTION
Allows user to pass attribute parameter. If no attribute parameter is passed, defaults to `src`. Useful for elements with `style='background-image(...)'`.

Sort of a different take on https://github.com/luis-almeida/unveil/pull/40.
