### PR TITLE
When -webkit-overflow-scrolling: touch no scroll events are fired

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -45,7 +45,7 @@
       images = images.not(loaded);
     }
 
-    $w.on("scroll.unveil resize.unveil lookup.unveil", unveil);
+    $w.on("scroll.unveil resize.unveil lookup.unveil touchend.unveil", unveil);
 
     unveil();
 


### PR DESCRIPTION
Safari on mobile supports the -webkit-overflow-scrolling CSS directive to create native-like scrolling experience (motion scroll that gradually stops and overscroll). However, when it's used, the browser doesn't fire the scroll events which causes unveil to not fire. This is especially problematic for Cordova apps.

It's fixed here by binding to the 'touchend' event in addition to 'scroll'.
