### PR TITLE
add jQuery package dependency for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,4 +2,7 @@
   "name": "jquery-unveil",
   "version": "1.3.0",
   "main": ["jquery.unveil.js"]
+  "dependencies": {
+    "jquery": ">=1.7"
+  },
 }


### PR DESCRIPTION
Just noticed, that the bower command doesn't automatically pull jQuery as well – hopefully fixed by this change. 
