### PR TITLE
Updated to allow different data attributes if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ That's what I did and this is my lightweight version of Lazy Load with support f
 Visit unveil's [project page](http://luis-almeida.github.com/unveil/) to read the documentation and see the demo.
 
 
+###Change the attribute Unveil targets by passing an object as the first parameter
+
+
+
+$("img").unveil({
+  threshold: 10,
+  attrib: 'data-unveil-src',
+  retinaAttrib: 'data-unveil-retina-src',
+  callback: function() {}
+});
+
+
 ###Browser support
 Compatible with All Browsers and IE7+.
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Visit unveil's [project page](http://luis-almeida.github.com/unveil/) to read th
 ###Change the attribute Unveil targets by passing an object as the first parameter
 
 
-
+```javascript
 $("img").unveil({
   threshold: 10,
   attrib: 'data-unveil-src',
   retinaAttrib: 'data-unveil-retina-src',
   callback: function() {}
 });
+```
 
 
 ###Browser support

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -10,18 +10,46 @@
 
 ;(function($) {
 
-  $.fn.unveil = function(threshold, callback) {
+  $.fn.unveil = function(args, callback) {
+
+    // unveil's original attribute names
+    var ATTRIB = "data-src";
+    var RETINA_ATTRIB = "data-src-retina"
+
+    // set the defaults for the data attributes
+    var attribName = {
+      standard: ATTRIB,
+      retina: RETINA_ATTRIB
+    }
+
+    var threshold,
+      callback;
+
+    // determine if the first parameter is an object or number
+    if (typeof args === "object") {
+      threshold = args.threshold;
+      callback = args.callback;
+      if (typeof args.attrib === "string") {
+        attribName.standard = args.attrib;
+      }
+      if (typeof args.retinaAttrib === "string") {
+        attribName.retina = args.retinaAttrib;
+      }
+    } else {
+      threshold = args;
+      callback = callback;
+    }
 
     var $w = $(window),
         th = threshold || 0,
         retina = window.devicePixelRatio > 1,
-        attrib = retina? "data-src-retina" : "data-src",
+        attrib = retina ? attribName.retina : attribName.standard,
         images = this,
         loaded;
 
     this.one("unveil", function() {
       var source = this.getAttribute(attrib);
-      source = source || this.getAttribute("data-src");
+      source = source || this.getAttribute(attribName.standard);
       if (source) {
         this.setAttribute("src", source);
         if (typeof callback === "function") callback.call(this);
@@ -44,7 +72,6 @@
       loaded = inview.trigger("unveil");
       images = images.not(loaded);
     }
-
     $w.on("scroll.unveil resize.unveil lookup.unveil", unveil);
 
     unveil();


### PR DESCRIPTION
I wanted to use Unveil in an Angular project but since Angular takes control of the data-src attribute I needed to be able to change the data attribute Unveil targets for an image src. 

This can be done with the following syntax. 

```
$(element).unveil({
    attrib: 'data-unveil-src',
    retinaAttrib: 'data-unveil-retina-src'
});
```

You should be able to supply one or the other or neither and Unveil will continue to work as it always has.
