### PR TITLE
Feature: Revert to original image on error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "jquery-unveil",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": ["jquery.unveil.js"]
 }

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,8 +23,12 @@
       var source = this.getAttribute(attrib);
       source = source || this.getAttribute("data-src");
       if (source) {
+        var originalsrc = this.getAttribute("src");
         this.setAttribute("src", source);
         if (typeof callback === "function") callback.call(this);
+        $(this).one("error", function () {
+          this.setAttribute("src", originalsrc);
+        });
       }
     });
 


### PR DESCRIPTION
We load a lot of images occasionally fails to download. Broken images cause page look worse than the original placeholder.
