### PR TITLE
Update docs for jQuery 3.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     }</code>
     <br><br>
     <code>$(<span class="red">"img"</span>).unveil(<span class="purple">200</span>, <span class="blue">function</span>() {<br>
-    &nbsp;&nbsp;$(this).load(<span class="blue">function</span>() {<br>
+    &nbsp;&nbsp;$(this).on(<span class="red">'load'</span>, <span class="blue">function</span>() {<br>
     &nbsp;&nbsp;&nbsp;&nbsp;this.style.opacity = 1;<br>
     &nbsp;&nbsp;});<br>
     });</code>


### PR DESCRIPTION
This code has a bug in it
![screenshot 2016-12-14 11 21 44](https://cloud.githubusercontent.com/assets/7920702/21164801/8179c78a-c1ef-11e6-8b0b-bdd930796da3.png)

In jQuery 3.0 the `.load()` method has been removed: https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed