### PR TITLE
Add support for watching elements other than window

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -10,9 +10,10 @@
 
 ;(function($) {
 
-  $.fn.unveil = function(threshold, callback) {
+  $.fn.unveil = function(threshold, callback, selectorsToWatch) {
 
     var $w = $(window),
+        $stw = selectorsToWatch ? $(selectorsToWatch) : $w,
         th = threshold || 0,
         retina = window.devicePixelRatio > 1,
         attrib = retina? "data-src-retina" : "data-src",
@@ -36,16 +37,18 @@
         var wt = $w.scrollTop(),
             wb = wt + $w.height(),
             et = $e.offset().top,
-            eb = et + $e.height();
+           eb = et + $e.height(),
+					ww = $w.width(),
+					el = $e.offset().left;
 
-        return eb >= wt - th && et <= wb + th;
+				return eb >= wt - th && et <= wb + th && el <= ww;
       });
 
       loaded = inview.trigger("unveil");
       images = images.not(loaded);
     }
 
-    $w.on("scroll.unveil resize.unveil lookup.unveil", unveil);
+    $stw.on("scroll.unveil resize.unveil lookup.unveil transitionend.unveil transitionstart.unveil", unveil);
 
     unveil();
 

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -37,11 +37,11 @@
         var wt = $w.scrollTop(),
             wb = wt + $w.height(),
             et = $e.offset().top,
-           eb = et + $e.height(),
-					ww = $w.width(),
-					el = $e.offset().left;
+            eb = et + $e.height(),
+	    ww = $w.width(),
+	    el = $e.offset().left;
 
-				return eb >= wt - th && et <= wb + th && el <= ww;
+         return eb >= wt - th && et <= wb + th && el <= ww;
       });
 
       loaded = inview.trigger("unveil");


### PR DESCRIPTION
So, I loved how small this code is, but needed just a little bit more functionality of detecting other elements that are off to the SIDE of the screen, not just below the fold.  Also allows to watch scrolling of a parent or other element (incase images are nested) incase the images are in a modal or side-drawer (that was my use case) and you've frozen the body to not allow any scrolling.  This will allow for that.  Didn't know if you guys have purposely left it out, but I thought I'd share with you incase you wanted to add it to your code.  Doesn't add much complexity, but does increase usability :)  