### PR TITLE
Jquery CDN URL updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
     </style>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="jquery.unveil.js"></script>
 
     <script>


### PR DESCRIPTION
Library was not loading because https: prefix was not added