### PR TITLE
feat: add package.json to make it valid NPM package

### DIFF
--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,7 +23,11 @@
       var source = this.getAttribute(attrib);
       source = source || this.getAttribute("data-src");
       if (source) {
-        this.setAttribute("src", source);
+        if (this.tagName === "img") {
+          this.setAttribute("src", source);
+        } else {
+          this.style["background-image"] = "url('" + source + "')";
+        }
         if (typeof callback === "function") callback.call(this);
       }
     });

--- a/jquery.unveil.js
+++ b/jquery.unveil.js
@@ -23,10 +23,10 @@
       var source = this.getAttribute(attrib);
       source = source || this.getAttribute("data-src");
       if (source) {
-        if (this.tagName === "img") {
+        if (this.tagName === "IMG") {
           this.setAttribute("src", source);
         } else {
-          this.style["background-image"] = "url('" + source + "')";
+          this.style["backgroundImage"] = "url('" + source + "')";
         }
         if (typeof callback === "function") callback.call(this);
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "unveil",
+  "version": "1.3.0",
+  "description": "A very lightweight jQuery plugin to lazy load images",
+  "main": "jquery.unveil.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luis-almeida/unveil.git"
+  },
+  "keywords": [
+    "jQuery",
+    "'lazy",
+    "load'"
+  ],
+  "author": "Luis Almeida",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/luis-almeida/unveil/issues"
+  },
+  "homepage": "https://github.com/luis-almeida/unveil#readme"
+}


### PR DESCRIPTION
From what I see this lib has been abandoned and I am OK with it. I have a project where `jquery.unveil.js` file is present as a part of `verndors` dir and I would like to have it 'imported' through `package.json`. so I need this to have also that file